### PR TITLE
patch: surface information about failing installs as part of stderr

### DIFF
--- a/libs/pyodide-sandbox-js/deno.json
+++ b/libs/pyodide-sandbox-js/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyurtsev/pyodide-sandbox",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "description": "CLI for running sandboxed Python code using Pyodide",
   "exports": "./main.ts",

--- a/libs/pyodide-sandbox-js/main.ts
+++ b/libs/pyodide-sandbox-js/main.ts
@@ -397,7 +397,7 @@ OPTIONS:
   // Exit with error code if Python execution failed
   // Create output JSON with stdout, stderr, and result
   const outputJson = {
-    stdout: result.success ? (result.stdout?.join('') || null) : null,
+    stdout: result.stdout?.join('') || null,
     stderr: result.success ? (result.stderr?.join('') || null) : result.error || null,
     result: result.success ? JSON.parse(result.jsonResult || 'null') : null,
     success: result.success,

--- a/libs/pyodide-sandbox-js/main.ts
+++ b/libs/pyodide-sandbox-js/main.ts
@@ -94,7 +94,7 @@ async def install_imports(
 
         for entry in to_install:
             try:
-              print(await micropip.install(entry["package"]))
+              await micropip.install(entry["package"])
             except Exception as e:
               message_callback("failed", entry["package"])
               break # Fail fast

--- a/libs/pyodide-sandbox-js/main_test.ts
+++ b/libs/pyodide-sandbox-js/main_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertNotEquals, assertExists } from "@std/assert";
 import { runPython } from "./main.ts";
 
 Deno.test("runPython simple test", async () => {
@@ -7,7 +7,33 @@ Deno.test("runPython simple test", async () => {
   assertEquals(JSON.parse(result.jsonResult || "null"), 5);
 });
 
-Deno.test("runPython with error", async () => {
+Deno.test("runPython with stdout", async () => {
+  const result = await runPython("x = 5; print(x); x", {});
+  assertEquals(result.success, true);
+  assertEquals(result.stdout?.join(''), "5");
+  assertEquals(JSON.parse(result.jsonResult || "null"), 5);
+  assertEquals(result.stderr?.length, 0);
+});
+
+Deno.test("runPython with error - division by zero", async () => {
   const result = await runPython("x = 1/0", {});
   assertEquals(result.success, false);
+  assertNotEquals(result.error?.length, 0);
+  assertEquals(result.error?.includes("ZeroDivisionError"), true);
+});
+
+Deno.test("runPython with error - syntax error", async () => {
+  const result = await runPython("x = 5; y = x +", {});
+  assertEquals(result.success, false);
+  assertNotEquals(result.error?.length, 0);
+  // Check that error contains SyntaxError
+  assertEquals(result.error?.includes("SyntaxError"), true);
+});
+
+Deno.test("runPython with error - name error", async () => {
+  const result = await runPython("undefined_variable", {});
+  assertEquals(result.success, false);
+  assertExists(result.error);
+  // Check that error contains NameError
+  assertEquals(result.error?.includes("NameError"), true);
 });


### PR DESCRIPTION
```shell
deno -A main.ts -c "import funcy; import langchain"
```

```json
{
  "stdout": null,
  "stderr": "Failed to install required Python packages: langchain. This is likely because these packages are not available in the Pyodide environment. Pyodide is a Python runtime that runs in the browser and has a limited set of pre-built packages. You may need to use alternative packages that are compatible with Pyodide.",
  "result": null,
  "success": false
}

```