### PR TITLE
(fix)Execution fails if the session_bytes is too long

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /.github
+    schedule:
+      interval: 'weekly'
+      day: 'sunday'
+      time: '14:00'
+      timezone: 'Asia/Jerusalem'
+    open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: 'weekly'
+      day: 'sunday'
+      time: '14:00'
+      timezone: 'Asia/Jerusalem'
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-patch
+  - package-ecosystem: pip
+    directory: /apps/ai
+    schedule:
+      interval: 'weekly'
+      day: 'sunday'
+      time: '14:00'
+      timezone: 'Asia/Jerusalem'
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-patch
+      - dependency-name: 'python'
+        versions: ['> 3.13.0']


### PR DESCRIPTION
This fixes a bug that happens when the `session_bytes` become too long due to large state declared.

Before the fix, a long `session_bytes` would cause `OSError: [Errno 7] Argument list too long: 'deno'` as the length of command becomes too long (see added test cases).

The fix is to use stdin to pipe the bytes from Python to Deno.