### PR TITLE
fix: missing newline on multi-line output

### DIFF
--- a/libs/pyodide-sandbox-js/main.ts
+++ b/libs/pyodide-sandbox-js/main.ts
@@ -397,8 +397,8 @@ OPTIONS:
   // Exit with error code if Python execution failed
   // Create output JSON with stdout, stderr, and result
   const outputJson = {
-    stdout: result.stdout?.join('') || null,
-    stderr: result.success ? (result.stderr?.join('') || null) : result.error || null,
+    stdout: result.stdout?.join('\n') || null,
+    stderr: result.success ? (result.stderr?.join('\n') || null) : result.error || null,
     result: result.success ? JSON.parse(result.jsonResult || 'null') : null,
     success: result.success,
     sessionBytes: result.sessionBytes,

--- a/libs/pyodide-sandbox-js/main_test.ts
+++ b/libs/pyodide-sandbox-js/main_test.ts
@@ -37,3 +37,9 @@ Deno.test("runPython with error - name error", async () => {
   // Check that error contains NameError
   assertEquals(result.error?.includes("NameError"), true);
 });
+
+Deno.test("runPython with multi-line print", async () => {
+  const result = await runPython("print('hello\\nworld')", {});
+  assertEquals(result.success, true);
+  assertEquals(result.stdout?.join('\n'), "hello\nworld");
+});


### PR DESCRIPTION

As stated in the Pyodide documentation, the stdout and stderr of loadPyodide are callbacks triggered per line of output. Therefore, the final result needs to be joined using \n.

https://github.com/pyodide/pyodide/blob/2957085abec190a54652af7555830617397085ed/docs/usage/faq.md#how-can-i-control-the-behavior-of-stdin--stdout--stderr

<img width="2148" height="676" alt="image" src="https://github.com/user-attachments/assets/6403d706-c40a-4fb3-b68e-444dfa0b4150" />
