### PR TITLE
Fix typo in README for 'allow_net' usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ LangChain Sandbox provides a secure environment for executing untrusted Python c
 
 
 > [!warning]
-> Use `alllow_net` to limit the network requests that can be made by the sandboxed code to avoid SSRF attacks
+> Use `allow_net` to limit the network requests that can be made by the sandboxed code to avoid SSRF attacks
 > https://docs.deno.com/runtime/fundamentals/security/#network-access
 
 ```python


### PR DESCRIPTION
Corrected a typo in the README regarding 'allow_net'.